### PR TITLE
fix: 修复在选择随机坐骑时，打开设置弹窗会导致UI错误

### DIFF
--- a/ffxiv_visland/Gathering/GatherWindow.cs
+++ b/ffxiv_visland/Gathering/GatherWindow.cs
@@ -224,13 +224,13 @@ public class GatherWindow : Window, IDisposable
                 RouteDB.NotifyModified();
             if (ImGui.SliderFloat("默认交互半径", ref RouteDB.DefaultInteractionRadius, 0, 100))
                 RouteDB.NotifyModified();
-            if (ImGui.BeginCombo("默认坐骑", _mounts![(uint)RouteDB.SelectedMount].Singular.RawString))
+            if (ImGui.BeginCombo("默认坐骑", RouteDB.SelectedMount <= 0 ? "随机坐骑" : _mounts![(uint)RouteDB.SelectedMount].Singular.RawString))
             {
                 ImGui.InputText("###MountSearchInput", ref mountSearchString, 100);
 
                 ImGui.Separator();
 
-                if (ImGui.Selectable("随机坐骑", RouteDB.SelectedMount < 0))
+                if (ImGui.Selectable("随机坐骑", RouteDB.SelectedMount <= 0))
                 {
                     RouteDB.SelectedMount = 0;
                     RouteDB.NotifyModified();


### PR DESCRIPTION
### 当前

![image](https://github.com/AtmoOmen/ffxiv_visland-cn/assets/102887808/58f947b3-3cfd-4abc-9454-12669663f962)

```
15:41:08.926 | ERR | [WindowSystem] Error during Draw(): 采集自动化
	System.Collections.Generic.KeyNotFoundException: The given key '0' was not present in the dictionary.
	   at visland.Gathering.GatherWindow.DrawRouteSettingsPopup() in D:\young\Documents\GitHub\ffxiv_visland-cn\ffxiv_visland\Gathering\GatherWindow.cs:line 227
	   at visland.Gathering.GatherWindow.DrawSidebar(Vector2 size) in D:\young\Documents\GitHub\ffxiv_visland-cn\ffxiv_visland\Gathering\GatherWindow.cs:line 183
	   at visland.Gathering.GatherWindow.Draw() in D:\young\Documents\GitHub\ffxiv_visland-cn\ffxiv_visland\Gathering\GatherWindow.cs:line 91
	   at Dalamud.Interface.Windowing.Window.DrawInternal(DalamudConfiguration configuration)
```

### 修复后

![image](https://github.com/AtmoOmen/ffxiv_visland-cn/assets/102887808/7099adcc-2495-49ab-92f9-9e5707358192)
